### PR TITLE
Escape shell parameters for updraft action

### DIFF
--- a/fastlane/actions/updraft.rb
+++ b/fastlane/actions/updraft.rb
@@ -26,7 +26,7 @@ module Fastlane
           curl_command << " -F 'app=@#{path.shellescape}'"
           curl_command << " -F 'custom_git_url=#{git_url.shellescape}'" unless git_url.empty?
           curl_command << " -F 'custom_git_branch=#{git_branch.shellescape}'" unless git_branch.empty?
-          curl_command << " -F 'custom_git_tag=#{git_tag.shellescape}'" unless git_tash.empty?
+          curl_command << " -F 'custom_git_tag=#{git_tag.shellescape}'" unless git_tag.empty?
           curl_command << " -F 'custom_git_commit_hash=#{git_commit_hash.shellescape}'" unless git_commit_hash.empty?
           curl_command << " -F 'whats_new=#{whats_new.shellescape}'" unless whats_new.empty?
           curl_command << " -F 'custom_bundle_version=#{bundle_version.shellescape}'" unless bundle_version.empty?

--- a/fastlane/actions/updraft.rb
+++ b/fastlane/actions/updraft.rb
@@ -18,22 +18,18 @@ module Fastlane
 
           whats_new = params[:changelog]
 
-          if params[:ipa]
-            bundle_version = Fastlane::Actions::GetIpaInfoPlistValueAction.run(ipa: params[:ipa], key: "CFBundleVersion").to_s
-          else
-            bundle_version = ""
-          end
+          bundle_version = params[:ipa] ? Fastlane::Actions::GetIpaInfoPlistValueAction.run(ipa: params[:ipa], key: "CFBundleVersion").to_s.strip : ""
 
           build_type = other_action.is_ci? ? "CI" : "Fastlane"
 
           curl_command = "curl -X PUT"
           curl_command << " -F 'app=@#{path.shellescape}'"
-          curl_command << " -F 'custom_git_url=#{git_url.shellescape}'"
-          curl_command << " -F 'custom_git_branch=#{git_branch.shellescape}'"
-          curl_command << " -F 'custom_git_tag=#{git_tag.shellescape}'"
-          curl_command << " -F 'custom_git_commit_hash=#{git_commit_hash.shellescape}'"
-          curl_command << " -F 'whats_new=#{whats_new.shellescape}'"
-          curl_command << " -F 'custom_bundle_version=#{bundle_version.shellescape}'"
+          curl_command << " -F 'custom_git_url=#{git_url.shellescape}'" unless git_url.empty?
+          curl_command << " -F 'custom_git_branch=#{git_branch.shellescape}'" unless git_branch.empty?
+          curl_command << " -F 'custom_git_tag=#{git_tag.shellescape}'" unless git_tash.empty?
+          curl_command << " -F 'custom_git_commit_hash=#{git_commit_hash.shellescape}'" unless git_commit_hash.empty?
+          curl_command << " -F 'whats_new=#{whats_new.shellescape}'" unless whats_new.empty?
+          curl_command << " -F 'custom_bundle_version=#{bundle_version.shellescape}'" unless bundle_version.empty?
           curl_command << " -F 'build_type=#{build_type.shellescape}'"
           curl_command << " " << params[:upload_url].shellescape
           curl_command << " --http1.1"

--- a/fastlane/actions/updraft.rb
+++ b/fastlane/actions/updraft.rb
@@ -25,15 +25,15 @@ module Fastlane
           build_type = other_action.is_ci? ? "CI" : "Fastlane"
 
           curl_command = "curl -X PUT"
-          curl_command << " -F 'app=@#{path}'"
-          curl_command << " -F 'custom_git_url=#{git_url}'"
-          curl_command << " -F 'custom_git_branch=#{git_branch}'"
-          curl_command << " -F 'custom_git_tag=#{git_tag}'"
-          curl_command << " -F 'custom_git_commit_hash=#{git_commit_hash}'"
-          curl_command << " -F 'whats_new=#{whats_new}'"
-          curl_command << " -F 'custom_bundle_version=#{bundle_version}'"
-          curl_command << " -F 'build_type=#{build_type}'"
-          curl_command << " " << params[:upload_url]
+          curl_command << " -F 'app=@#{path.shellescape}'"
+          curl_command << " -F 'custom_git_url=#{git_url.shellescape}'"
+          curl_command << " -F 'custom_git_branch=#{git_branch.shellescape}'"
+          curl_command << " -F 'custom_git_tag=#{git_tag.shellescape}'"
+          curl_command << " -F 'custom_git_commit_hash=#{git_commit_hash.shellescape}'"
+          curl_command << " -F 'whats_new=#{whats_new.shellescape}'"
+          curl_command << " -F 'custom_bundle_version=#{bundle_version.shellescape}'"
+          curl_command << " -F 'build_type=#{build_type.shellescape}'"
+          curl_command << " " << params[:upload_url].shellescape
           curl_command << " --http1.1"
 
           UI.important("Uploading build to Updraft. This might take a while...")

--- a/fastlane/actions/updraft.rb
+++ b/fastlane/actions/updraft.rb
@@ -23,14 +23,14 @@ module Fastlane
           build_type = other_action.is_ci? ? "CI" : "Fastlane"
 
           curl_command = "curl -X PUT"
-          curl_command << " -F 'app=@#{path.shellescape}'"
-          curl_command << " -F 'custom_git_url=#{git_url.shellescape}'" unless git_url.empty?
-          curl_command << " -F 'custom_git_branch=#{git_branch.shellescape}'" unless git_branch.empty?
-          curl_command << " -F 'custom_git_tag=#{git_tag.shellescape}'" unless git_tag.empty?
-          curl_command << " -F 'custom_git_commit_hash=#{git_commit_hash.shellescape}'" unless git_commit_hash.empty?
-          curl_command << " -F 'whats_new=#{whats_new.shellescape}'" unless whats_new.empty?
-          curl_command << " -F 'custom_bundle_version=#{bundle_version.shellescape}'" unless bundle_version.empty?
-          curl_command << " -F 'build_type=#{build_type.shellescape}'"
+          curl_command << " -F app=@#{path.shellescape}"
+          curl_command << " -F custom_git_url=#{git_url.shellescape}" unless git_url.empty?
+          curl_command << " -F custom_git_branch=#{git_branch.shellescape}" unless git_branch.empty?
+          curl_command << " -F custom_git_tag=#{git_tag.shellescape}" unless git_tag.empty?
+          curl_command << " -F custom_git_commit_hash=#{git_commit_hash.shellescape}" unless git_commit_hash.empty?
+          curl_command << " -F whats_new=#{whats_new.shellescape}" unless whats_new.empty?
+          curl_command << " -F custom_bundle_version=#{bundle_version.shellescape}" unless bundle_version.empty?
+          curl_command << " -F build_type=#{build_type.shellescape}"
           curl_command << " " << params[:upload_url].shellescape
           curl_command << " --http1.1"
 

--- a/fastlane/actions/updraft.rb
+++ b/fastlane/actions/updraft.rb
@@ -20,6 +20,8 @@ module Fastlane
 
           if params[:ipa]
             bundle_version = Fastlane::Actions::GetIpaInfoPlistValueAction.run(ipa: params[:ipa], key: "CFBundleVersion").to_s
+          else
+            bundle_version = ""
           end
 
           build_type = other_action.is_ci? ? "CI" : "Fastlane"


### PR DESCRIPTION
- Introduces usage of `.shellescape` for parameters passed to updraft action. 
- Removes additional unneeded string character `'` from curl parameters
- Remove of empty parameters before upload

Fixes #4 

Reference: 
https://github.com/fastlane/fastlane/discussions/21676
https://github.com/fastlane/fastlane/pull/13230